### PR TITLE
Fix FTBFS by a type mismatch of sqlite3BtreeCachedRowidSet()

### DIFF
--- a/src/rowlock.h
+++ b/src/rowlock.h
@@ -98,7 +98,7 @@ int sqlite3BtreeAdvanceAll(BtCursor *pCur, int flags, int(*xAdvance)(BtCursor*, 
 #define sqlite3BtreeNextAll(pCur, flags) sqlite3BtreeAdvanceAll(pCur, sqlite3BtreeNext, flags)
 
 void sqlite3BtreeCachedRowidFlagSet(BtCursor *pCur, u8 flag);
-void sqlite3BtreeCachedRowidSet(BtCursor *pCur, u64 iRowid);
+void sqlite3BtreeCachedRowidSet(BtCursor *pCur, i64 iRowid);
 i64 sqlite3BtreeCachedRowidGet(BtCursor *pCur);
 int sqlite3BtreeCachedRowidSetByOpenCursor(BtCursor *pCur);
 


### PR DESCRIPTION
----
sqlite3.c: At top level:
sqlite3.c:149788:21: error: conflicting types for ‘sqlite3BtreeCachedRowidSet’
 SQLITE_PRIVATE void sqlite3BtreeCachedRowidSet(BtCursor *pCur, i64 iRowid){
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
sqlite3.c:62865:21: note: previous declaration of ‘sqlite3BtreeCachedRowidSet’ was here
 SQLITE_PRIVATE void sqlite3BtreeCachedRowidSet(BtCursor *pCur, u64 iRowid);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
sqlite3.c:62865:21: warning: ‘sqlite3BtreeCachedRowidSet’ used but never defined
----

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro1.iwamatsu@toshiba.co.jp>